### PR TITLE
feat: sort by event end date if start dates are equal

### DIFF
--- a/src/utils/eventLevels.js
+++ b/src/utils/eventLevels.js
@@ -95,6 +95,7 @@ export function sortEvents(evtA, evtB, accessors) {
     startSort || // sort by start Day first
     Math.max(durB, 1) - Math.max(durA, 1) || // events spanning multiple days go first
     !!accessors.allDay(evtB) - !!accessors.allDay(evtA) || // then allDay single day events
-    +accessors.start(evtA) - +accessors.start(evtB)
-  ) // then sort by start time
+    +accessors.start(evtA) - +accessors.start(evtB) || // then sort by start time
+    +accessors.end(evtA) - +accessors.end(evtB) // then sort by end time
+  )
 }


### PR DESCRIPTION
This PR adds an extra sort option after sorting by event start date, which sorts events that stop earlier before those that stop later.

Example of what could happen for any given (same) day:
| Before patch - end not sorted | After patch - end sorted |
|----|----|
| 12:00-12:30 event a | 12:00-12:30 event a |
| 12:00-13:30 event c | 12:00-13:00 event b |
| 12:00-13:00 event b | 12:00-13:30 event c |

Fixes #1898 