### PR TITLE
fix: upgrade uncontrollable to v9 for React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "moment-timezone": "^0.5.48",
     "prop-types": "^15.8.1",
     "react-overlays": "^5.2.1",
-    "uncontrollable": "^7.2.1"
+    "uncontrollable": "^9.0.0"
   },
   "bugs": {
     "url": "https://github.com/bigcalendar/react-big-calendar/issues"

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { uncontrollable } from 'uncontrollable'
+import { useUncontrolled } from 'uncontrollable'
 import {
   accessor,
   views as componentViews,
@@ -1183,8 +1183,18 @@ class Calendar extends React.Component {
   }
 }
 
-export default uncontrollable(Calendar, {
-  view: 'onView',
-  date: 'onNavigate',
-  selected: 'onSelectEvent',
-})
+const UncontrolledCalendar = React.forwardRef(
+  function UncontrolledCalendar(props, ref) {
+    const controlledProps = useUncontrolled(props, {
+      view: 'onView',
+      date: 'onNavigate',
+      selected: 'onSelectEvent',
+    })
+
+    return <Calendar ref={ref} {...controlledProps} />
+  }
+)
+
+UncontrolledCalendar.propTypes = Calendar.propTypes
+
+export default UncontrolledCalendar

--- a/yarn.lock
+++ b/yarn.lock
@@ -11402,6 +11402,11 @@ uncontrollable@^7.2.1:
     invariant "^2.2.4"
     react-lifecycles-compat "^3.0.4"
 
+uncontrollable@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-9.0.0.tgz#a20495552b1c23640edd530733ed8c57bf66c103"
+  integrity sha512-wPScOFmvRkHdvebf7qNPn9Wog9B1TL8Dqcx0Vecz6HYTKFKMfGKP6MJHTjiKL8kwd8KTW3YfIUke7pmRDtkcRQ==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"


### PR DESCRIPTION
Replace the uncontrollable HOC with a forwardRef wrapper using useUncontrolled.

Fixes calendar navigation under React 19 and Strict Mode.

Manifests in logs as:
```
Your app (or one of its dependencies) is using an outdated JSX transform. Update to the modern JSX transform for faster performance: https://react.dev/link/new-jsx-transform
```

Symptoms:
Calendar button navigation sometimes does not work to switch views.

Closes
https://github.com/bigcalendar/react-big-calendar/issues/2720
https://github.com/bigcalendar/react-big-calendar/issues/2434

-----------

Related:

- https://github.com/jquense/uncontrollable/issues/60

> Hey I appreciate the fix here but I'm probably not going to release a bug fix for a really old version. If RBC doesn't want to upgrade for whatever reason (totally up to them I get it's a lot of work) I'd recommend they vendor the code or fork the old version giving them the freedom to adjust as needed

-----------

- https://github.com/bigcalendar/react-big-calendar/pull/2738/changes

Missing forwardRef — tests and DnD rely on refs reaching the Calendar instance (ref.current.state, ref.current.handleRangeChange, etc.). Without forwardRef, that API breaks.

Do not put view / date / selected on the wrapper’s defaultProps — PR #2738 added:

defaultProps: { view: views.MONTH, date: new Date(), selected: null }
That makes those props always defined before useUncontrolled runs, so internal state never updates — exactly the “toolbar doesn’t work” behavior. The wrapper should not inherit view from Calendar.defaultProps; let useUncontrolled + Calendar.defaultProps handle defaults separately (same effective behavior as today’s HOC).

Optional propTypes — the old HOC added runtime propTypes for defaultDate and defaultSelected. You may want those on the wrapper for dev warnings; defaultView is already documented on Calendar.

-----------

- https://stackoverflow.com/questions/78011246/react-big-calendar-next-and-back-buttons-not-navigating-to-the-correct-month




